### PR TITLE
Improve mathjax filter work around for options with text and math

### DIFF
--- a/src/lib/render-moodle.ts
+++ b/src/lib/render-moodle.ts
@@ -36,8 +36,8 @@ const patchMoodleMathJaxFilterBreakage = (element: HTMLElement): void => {
     result = result.replaceAll('<span class=" nolink"="">', '')
     result = result.replaceAll('</span>', '')
     result = result.replaceAll('&gt;', '>')
-    result = result.replaceAll('"\\\\(', '&quot;\\\\(')
-    result = result.replaceAll('\\\\)"', '\\\\)&quot;')
+    result = result.replaceAll('"[', "'[")
+    result = result.replaceAll(']"', "]'")
 
     return result
   }


### PR DESCRIPTION
The previous fix was found to not work when using options that include
both text and math. This change tries to address that by attempting
to replace the outside quotes of the data attribute with single quotes
instead of trying to HTML encode internal quotes.