### PR TITLE
Address warning emitted by unit test case

### DIFF
--- a/src/tests/MoodleApi.test.ts
+++ b/src/tests/MoodleApi.test.ts
@@ -4,7 +4,7 @@ import { setupServer } from 'msw/node'
 import { rest } from 'msw'
 
 const server = setupServer(
-  rest.post('http://moodle/lib/ajax/service.php?sesskey=12345&info=local_raise_get_user', (req, res, ctx) => {
+  rest.post('http://moodle/lib/ajax/service.php', (req, res, ctx) => {
     return res(ctx.json([{
       data: {
         uuid: 'uuid',


### PR DESCRIPTION
This PR is to address a warning I noticed when running tests from this repo:

```
> jest

  console.warn
    [MSW] Found a redundant usage of query parameters in the request handler URL for "POST http://moodle/lib/ajax/service.php?sesskey=12345&info=local_raise_get_user". Please match against a path instead and access query parameters in the response resolver function using "req.url.searchParams".

       5 |
       6 | const server = setupServer(
    >  7 |   rest.post('http://moodle/lib/ajax/service.php?sesskey=12345&info=local_raise_get_user', (req, res, ctx) => {
         |        ^
       8 |     return res(ctx.json([{
       9 |       data: {
      10 |         uuid: 'uuid',

      at Object.warn (node_modules/msw/src/utils/internal/devUtils.ts:17:11)
      at RestHandler.checkRedundantQueryParameters (node_modules/msw/src/handlers/RestHandler.ts:148:14)
      at new RestHandler (node_modules/msw/src/handlers/RestHandler.ts:124:10)
      at Object.post (node_modules/msw/src/rest.ts:30:12)
      at Object.<anonymous> (src/tests/MoodleApi.test.ts:7:8)
```

It looks like the mocker doesn't need the query parameters to match so we can just clean that up to avoid the warning.