### PR TITLE
Add value prop to Mathfield so it can be controlled

### DIFF
--- a/src/components/Mathfield.tsx
+++ b/src/components/Mathfield.tsx
@@ -16,9 +16,10 @@ interface MathfieldProps {
   onInput: (event: React.ChangeEvent<MathfieldElement>) => void
   className: string
   disabled: boolean
+  value: string
 }
 
-export const Mathfield = ({ className, disabled, onInput }: MathfieldProps): JSX.Element => {
+export const Mathfield = ({ className, disabled, onInput, value }: MathfieldProps): JSX.Element => {
   const mathfieldRef = useRef<MathfieldElement>(null)
   useEffect(() => {
     const mathFieldCurrent = mathfieldRef.current
@@ -55,7 +56,9 @@ export const Mathfield = ({ className, disabled, onInput }: MathfieldProps): JSX
         pointerEventSpan.style.pointerEvents = 'auto'
       }
     }
-  }, [disabled])
+
+    mathFieldCurrent.value = value
+  }, [disabled, value])
 
   return (
     <>

--- a/src/components/Mathfield.tsx
+++ b/src/components/Mathfield.tsx
@@ -56,9 +56,16 @@ export const Mathfield = ({ className, disabled, onInput, value }: MathfieldProp
         pointerEventSpan.style.pointerEvents = 'auto'
       }
     }
+  }, [disabled])
+
+  useEffect(() => {
+    const mathFieldCurrent = mathfieldRef.current
+    if ((mathFieldCurrent === null)) {
+      return
+    }
 
     mathFieldCurrent.value = value
-  }, [disabled, value])
+  }, [value])
 
   return (
     <>


### PR DESCRIPTION
I spun this up as a one-off PR to the spike branch after @MReyna12 and I had a conversation + realized that the persisted values were not being rendered properly for `math` input problems. I think this fixes things :man_shrugging: .